### PR TITLE
Update ./docker-run-test/run-query-bench-docker.sh

### DIFF
--- a/docker-run-test/run-query-bench-docker.sh
+++ b/docker-run-test/run-query-bench-docker.sh
@@ -10,6 +10,6 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 docker run --net=host -v "$SCRIPT_DIR":/app/tmp -it \
-  graphql-bench-test:latest query \
+  graphql-bench-local:latest query \
   --config="./tmp/config.query.yaml" \
   --outfile="./tmp/report.json"


### PR DESCRIPTION
"make build_local_docker_image" creates graphql-bench-local:latest docker_image.
But "make run_docker_query_bench" tries to run graphql-bench-test:latest docker_image.
Made necessary change in "./docker-run-test/run-query-bench-docker.sh" file.

resolve #26 