### PR TITLE
Add a variable file to pass a list of variables to parameterised Queries/Subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,15 @@ queries:
     execution_strategy: FIXED_REQUEST_NUMBER
     requests: 10000
     query: |
-      query AlbumByPK {
-        albums_by_pk(id: 1) {
+      query AlbumByPK($id: Int!) {
+        albums_by_pk(id: $id) {
           id
           title
         }
       }
+    # Optional variables (if the query/mutation uses variables)
+    variables:
+      id: 1
   - name: AlbumByPKMultiStage
     tools: [k6]
     execution_strategy: MULTI_STAGE
@@ -160,12 +163,15 @@ queries:
       - duration: 5s
         target: 1000
     query: |
-      query AlbumByPK {
-        albums_by_pk(id: 1) {
+      query AlbumByPK($id: Int!) {
+        albums_by_pk(id: $id) {
           id
           title
         }
-      }
+      }    
+    # Supply variables (Optional) from CSV file. Each row in the CSV is used in a request. (If 100 rows are provided, 100 queries with different variables are fired). The first row in the CSV must be name of the the variable. This can be used in tandem with the above variables.
+    variable_file:
+      file_path: './text.csv' # CSV file path releative to the config file
 ```
 
 ##### Run with Docker
@@ -241,6 +247,9 @@ config:
     artistIds: [1, 2, 3, 4]
     some_object:
       a_key: a_value
+  # Supply variables (Optional) from CSV file. Each row in the CSV is used in a Subscription.  The first row in the CSV must be name of the the variable. This can be used in tandem with the above variables.
+  variable_file:
+    file_path: './text.csv' # CSV file path releative to the config file
 ```
 
 ##### Note: Required Table

--- a/app/cli/test.csv
+++ b/app/cli/test.csv
@@ -1,0 +1,5 @@
+id,name
+1,sandeep
+2,raj
+3,kumar
+4,kandasamy

--- a/app/queries/bin/k6/loadScript.js
+++ b/app/queries/bin/k6/loadScript.js
@@ -1,15 +1,39 @@
 import http from 'k6/http'
 import { check } from 'k6'
 
+var cachedFileVariables;
+var fileVariablesCurrentIndex = 0;
+
+/**
+ * Use ES5 syntax
+ */
 export default function () {
-  let { url, headers, query, variables } = __ENV
+  let { url, headers, query, variables, fileVariables } = __ENV
 
   // Can't pass nested JSON in config file, need to parse here because stringified
   if (headers) headers = JSON.parse(headers)
   if (variables) variables = JSON.parse(variables)
+  // Storing the JSONified fileVariables to not deserialize in every iteration
+  if (!cachedFileVariables) {
+    cachedFileVariables = JSON.parse(fileVariables)
+  }
+
+  let combinedVariables;
+
+  if (cachedFileVariables.length!=0) {
+    // TODO: can look at getting a random value beween 0 and cachedFileVariables.length rather than iterating for ensured randomness
+    if (fileVariablesCurrentIndex >= cachedFileVariables.length) {
+      fileVariablesCurrentIndex = 0;
+    }    
+    combinedVariables = Object.assign({}, variables, cachedFileVariables[fileVariablesCurrentIndex]);  
+    fileVariablesCurrentIndex++;  
+  } else {
+    combinedVariables = variables;
+  }
+  
 
   // Prepare query & variables (if provided)
-  let body = JSON.stringify({ query, variables })
+  let body = JSON.stringify({ query, variables: combinedVariables })
 
   // Send the request
   let res = http.post(url, body, { headers })

--- a/app/queries/package.json
+++ b/app/queries/package.json
@@ -16,7 +16,8 @@
     "fs-extra": "^9.0.1",
     "hdr-histogram-js": "^2.0.0-beta6",
     "js-yaml": "^3.14.0",
-    "lookpath": "^1.1.0"
+    "lookpath": "^1.1.0",
+    "neat-csv": "^6.0.1"
   },
   "devDependencies": {
     "@types/autocannon": "^4.1.0"

--- a/app/queries/src/executors/autocannon/index.ts
+++ b/app/queries/src/executors/autocannon/index.ts
@@ -4,7 +4,7 @@
  * ========================
  */
 
-import { makeBenchmarkMetrics, BenchmarkExecutor } from '../base'
+import { makeBenchmarkMetrics, BenchmarkExecutor } from "../base";
 
 import {
   BenchmarkMetrics,
@@ -15,58 +15,92 @@ import {
   MaxRequestsInDurationBenchmark,
   MultiStageBenchmark,
   RequestsPerSecondBenchmark,
-} from '../base/types'
+} from "../base/types";
 
-import { RunAutocannonMetadata } from './types'
+import { RunAutocannonMetadata } from "./types";
 
-import autocannon from 'autocannon'
-import { Options as AutocannonOptions } from 'autocannon'
+import autocannon, { Client, Request } from "autocannon";
+import { Options as AutocannonOptions } from "autocannon";
 
-import fs from 'fs-extra'
-import path from 'path'
-import * as hdr from 'hdr-histogram-js'
+import fs from "fs-extra";
+import path from "path";
+import * as hdr from "hdr-histogram-js";
+import { Utils } from "../base/utils";
 
 export class AutocannonExecutor extends BenchmarkExecutor {
-  public tool = BenchmarkTool.AUTOCANNON
-  private reportPath = path.join(this.baseReportPath, 'autocannon')
+  public tool = BenchmarkTool.AUTOCANNON;
+  private reportPath = path.join(this.baseReportPath, "autocannon");
+
+  private benchMarkConfig: Benchmark;
+  private fileVariables: any[];
+  private fileVariablesCurrentIndex = 0;
 
   private _makeSharedFields(bench: Benchmark): AutocannonOptions {
     return {
       url: this.config.url,
-      headers: this.config.headers,
-      method: 'POST',
       connections: bench.connections || 10,
-      body: JSON.stringify({
-        query: bench.query,
-        variables: bench.variables,
-      }),
+      /**
+       * Sets the request body in each client. No. of clients created = no. of connections.
+       * For each client iterate over the variables (one row) read from the CSV file and set it in the request, thus each client queries with different variables.
+       * Suggested number of rows in CSV  = Number of connections. 
+       * @param client Autocannon client
+       */
+      setupClient: (client) => {
+        // If debug, log each response body
+        if (this.config.debug) {
+          client.on("body", console.log);
+        }
+        if (this.fileVariablesCurrentIndex >= this.fileVariables.length) {
+          this.fileVariablesCurrentIndex = 0;
+        }
+        let req: Request = {
+          headers: this.config.headers,
+          method: "POST",
+          body: JSON.stringify({
+            query: this.benchMarkConfig.query,
+            variables: { ...this.benchMarkConfig.variables, ...this.fileVariables[this.fileVariablesCurrentIndex] },
+          }),
+        };
+        client.setRequest(req);
+        this.fileVariablesCurrentIndex++;
+      }
+    };
+  }
+
+  
+
+  private _generateAutocannonMetadata(bench: Benchmark): RunAutocannonMetadata {
+    const queryName = this._makeBenchmarkName(bench)
+    return {
+      queryName,
+      outputFile: `${queryName}.json`
     }
   }
 
-  public runCustomBench(bench: CustomBenchmark) {
-    const baseOpts = this._makeSharedFields(bench)
-    const queryName = this._makeBenchmarkName(bench)
-    const metadata = {
-      queryName,
-      outputFile: `${queryName}.json`,
-    }
+  private async _generateAutoCannonOptions(bench: Benchmark): Promise<autocannon.Options> {
+    this.benchMarkConfig = bench;
+    this.fileVariables = await Utils.readVariablesFromFile(bench);
+
+    return this._makeSharedFields(bench)
+  }
+
+  public async runCustomBench(bench: CustomBenchmark) {
+    const baseOpts = await this._generateAutocannonMetadata(bench);
+    const metadata = this._generateAutocannonMetadata(bench)
     return this._runAutocannon(metadata, {
       ...baseOpts,
       ...bench.options.autocannon,
-    })
+    });
   }
 
   public runMultiStageBench(bench: MultiStageBenchmark): never {
-    throw new Error('Not Implemented')
+    throw new Error("Not Implemented");
   }
 
-  public runRequestsPerSecondBench(bench: RequestsPerSecondBenchmark) {
-    const baseOpts = this._makeSharedFields(bench)
-    const queryName = this._makeBenchmarkName(bench)
-    const metadata = {
-      queryName,
-      outputFile: `${queryName}.json`,
-    }
+  public async runRequestsPerSecondBench(bench: RequestsPerSecondBenchmark) {
+
+    const baseOpts = await this._generateAutoCannonOptions(bench)
+    const metadata = this._generateAutocannonMetadata(bench);
     return this._runAutocannon(metadata, {
       ...baseOpts,
       duration: bench.duration,
@@ -74,63 +108,53 @@ export class AutocannonExecutor extends BenchmarkExecutor {
     })
   }
 
-  public runFixedRequestNumberBench(bench: FixedRequestNumberBenchmark) {
-    const baseOpts = this._makeSharedFields(bench)
-    const queryName = this._makeBenchmarkName(bench)
-    const metadata = {
-      queryName,
-      outputFile: `${queryName}.json`,
-    }
+  public async runFixedRequestNumberBench(bench: FixedRequestNumberBenchmark) {
+    const baseOpts = await this._generateAutoCannonOptions(bench)
+    const metadata = this._generateAutocannonMetadata(bench);
     return this._runAutocannon(metadata, {
       ...baseOpts,
       amount: bench.requests,
-    })
+    });
   }
 
-  public runMaxRequestsInDurationBench(bench: MaxRequestsInDurationBenchmark) {
-    const baseOpts = this._makeSharedFields(bench)
-    const queryName = this._makeBenchmarkName(bench)
-    const metadata = {
-      queryName,
-      outputFile: `${queryName}.json`,
-    }
+  public async runMaxRequestsInDurationBench(bench: MaxRequestsInDurationBenchmark) {
+    const baseOpts = await this._generateAutoCannonOptions(bench)
+    const metadata = this._generateAutocannonMetadata(bench);
     return this._runAutocannon(metadata, {
       ...baseOpts,
       duration: bench.duration,
-    })
+    });
   }
 
+  // TODO: use worker threads, that means any function input to autocannon ned to go to separate js files which are "require"able
   private async _runAutocannon(
     metadata: RunAutocannonMetadata,
     config: AutocannonOptions
   ) {
-    const { queryName, outputFile } = metadata
-    // If debug, log each response body
-    if (this.config.debug)
-      config.setupClient = (client) => client.on('body', console.log)
+    const { queryName, outputFile } = metadata;
 
     const instance = autocannon(config, (err, results) => {
-      if (err) throw err
-    })
+      if (err) throw err;
+    });
 
-    const histogram = hdr.build()
-    instance.on('response', (client, statusCode, resBytes, responseTime) => {
-      histogram.recordValue(responseTime)
-    })
+    const histogram = hdr.build();
+    instance.on("response", (client, statusCode, resBytes, responseTime) => {
+      histogram.recordValue(responseTime);
+    });
 
     autocannon.track(instance, {
       outputStream: this.config.writeStream || process.stdout,
       renderProgressBar: true,
       renderLatencyTable: true,
       renderResultsTable: true,
-    })
+    });
 
     // Wrap this in a Promise to force waiting for Autocannon run to finish
     return new Promise<BenchmarkMetrics>((resolve) => {
-      instance.on('done', (results) => {
+      instance.on("done", (results) => {
         // Write Autocannon results object to output file
-        const outfile = path.join(this.reportPath, outputFile)
-        fs.outputJSONSync(outfile, results)
+        const outfile = path.join(this.reportPath, outputFile);
+        fs.outputJSONSync(outfile, results);
         // Build and return Metrics object
         const metrics = makeBenchmarkMetrics({
           name: metadata.queryName,
@@ -147,9 +171,9 @@ export class AutocannonExecutor extends BenchmarkExecutor {
             count: results.requests.total,
             average: results.requests.average,
           },
-        })
-        resolve(metrics)
-      })
-    })
+        });
+        resolve(metrics);
+      });
+    });
   }
 }

--- a/app/queries/src/executors/base/index.ts
+++ b/app/queries/src/executors/base/index.ts
@@ -68,7 +68,7 @@ export abstract class BenchmarkExecutor {
   public config: GlobalConfig
 
   /** Path to the configuration file to load */
-  private configPath = path.join(__dirname, '../../config.yaml')
+  // private configPath = path.join(__dirname, '../../config.yaml')
   /** Path to the reports directory */
   public baseReportPath = path.join(__dirname, '../../../reports')
 
@@ -99,8 +99,8 @@ export abstract class BenchmarkExecutor {
     }
   }
 
-  public readConfigFile(pathTo?: string): GlobalConfig {
-    const configFile = fs.readFileSync(pathTo || this.configPath, 'utf-8')
+  public readConfigFile(pathTo: string): GlobalConfig {
+    const configFile = fs.readFileSync(pathTo , 'utf-8')
     return yaml.load(configFile)
   }
 

--- a/app/queries/src/executors/base/types.ts
+++ b/app/queries/src/executors/base/types.ts
@@ -59,6 +59,11 @@ interface _BenchmarkRunConfig {
   query: string
   variables?: Record<string, any>
   connections?: number
+  variable_file?: VariableFile
+}
+
+export interface VariableFile {
+  file_path: string
 }
 
 /**

--- a/app/queries/src/executors/base/utils.ts
+++ b/app/queries/src/executors/base/utils.ts
@@ -1,0 +1,40 @@
+import neatCsv = require("neat-csv");
+import { Benchmark } from "./types";
+import fs from "fs-extra";
+import path from "path";
+
+
+export class Utils {
+
+    /**
+     * Asynchronously Read values from the CSV file and output as an Array of JSON values. The JSOn Object keys are the first row in the file, 
+     * which must also be the variable name. Also supports nested Variables which are themselves JSON.
+     * 
+     * @param bench Benchmark
+     * @returns neatCsv.Row[] - Array of objects pertaining to each row in the CSV file
+     */
+    static async readVariablesFromFile(bench: Benchmark) {
+        let output: neatCsv.Row[] = [];
+        if (
+            bench.variable_file &&
+            bench.variable_file.file_path
+        ) {
+            let varCsvFile = fs.createReadStream(
+                path.join(process.cwd(), bench.variable_file.file_path)
+            );
+            let rows = await neatCsv(varCsvFile);
+            rows.forEach((row) => {
+                const keys = Object.keys(row);
+                keys.forEach((key) => {
+                    try {
+                        row[key] = JSON.parse(row[key]);
+                    } catch (error) {
+                        // Suppress the unparseable json error.
+                    }
+                });
+            });
+            output = rows;
+        }
+        return output;
+    }
+}

--- a/app/queries/src/executors/wrk2/index.ts
+++ b/app/queries/src/executors/wrk2/index.ts
@@ -126,9 +126,9 @@ export class Wrk2Executor extends BenchmarkExecutor {
 
   public async runRequestsPerSecondBench(bench: RequestsPerSecondBenchmark) {
     const queryName = this._makeBenchmarkName(bench)
-    // console.log('Wrk2, runRequestsPerSecondBench:')
-    // console.log('Bench:', bench)
-    // console.log('queryName:', queryName)
+    console.log('Wrk2, runRequestsPerSecondBench:')
+    console.log('Bench:', bench)
+    console.log('queryName:', queryName)
     const metadata = {
       queryName,
       outputFile: `${queryName}.json`,

--- a/app/queries/src/executors/wrk2/index.ts
+++ b/app/queries/src/executors/wrk2/index.ts
@@ -26,6 +26,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import execa from 'execa'
 import { lookpath } from 'lookpath'
+import { Utils } from '../base/utils'
 
 export class Wrk2Executor extends BenchmarkExecutor {
   public tool = BenchmarkTool.WRK2
@@ -118,15 +119,16 @@ export class Wrk2Executor extends BenchmarkExecutor {
         query: bench.query,
         variables: bench.variables,
         headers: this.config.headers,
+        fileVariables: await Utils.readVariablesFromFile(bench)
       },
     })
   }
 
   public async runRequestsPerSecondBench(bench: RequestsPerSecondBenchmark) {
     const queryName = this._makeBenchmarkName(bench)
-    console.log('Wrk2, runRequestsPerSecondBench:')
-    console.log('Bench:', bench)
-    console.log('queryName:', queryName)
+    // console.log('Wrk2, runRequestsPerSecondBench:')
+    // console.log('Bench:', bench)
+    // console.log('queryName:', queryName)
     const metadata = {
       queryName,
       outputFile: `${queryName}.json`,
@@ -138,11 +140,13 @@ export class Wrk2Executor extends BenchmarkExecutor {
         latency: true,
         duration: bench.duration,
         rate: bench.rps,
+        connections: bench.connections // Add connections
       },
       config: {
         query: bench.query,
         variables: bench.variables,
         headers: this.config.headers,
+        fileVariables: await Utils.readVariablesFromFile(bench)
       },
     })
   }
@@ -162,12 +166,14 @@ export class Wrk2Executor extends BenchmarkExecutor {
     return args
   }
 
-  private async getBinaryPath() {
-    const defaultPath = await lookpath('wrk')
-    if (defaultPath) return defaultPath
+  private async getBinaryPath() {    
+    //  If available, Prefer local binary to wrk binary in PATH
     const localWrkBinary = path.join(this.localBinaryFolder, 'wrk/wrk')
     const localBinaryExists = await fs.pathExists(localWrkBinary)
     if (localBinaryExists) return localWrkBinary
+
+    const defaultPath = await lookpath('wrk')
+    if (defaultPath) return defaultPath
     throw new Error(
       'Could not find wrk binary either globally in $PATH or in local ./bin/wrk folder'
     )
@@ -194,7 +200,7 @@ export class Wrk2Executor extends BenchmarkExecutor {
     const output = await wrk
     const end = new Date()
 
-    const stats = JSON.parse(output.stderr)
+    const stats = (output.stderr) ? JSON.parse(output.stderr): null;
     // Also emits these same stats to stderr, so could make script not write stat file and just read from there
     // const stats: Wrk2StatsOutputJson = await fs.readJSON('/tmp/wrk2-stats.json')
     if (!stats) throw new Error('Failed reading stats output from wrk stderr')

--- a/app/queries/src/executors/wrk2/types.ts
+++ b/app/queries/src/executors/wrk2/types.ts
@@ -9,6 +9,7 @@ export interface Wrk2BinaryArgs {
     query: string
     variables?: Record<string, any>
     headers?: Record<string, any>
+    fileVariables?: Record<string, any>
   }
 }
 

--- a/app/subscriptions/package.json
+++ b/app/subscriptions/package.json
@@ -27,7 +27,8 @@
     "pg": "^8.2.1",
     "reattempt": "^0.1.1",
     "websocket-as-promised": "^1.0.1",
-    "ws": "^7.3.0"
+    "ws": "^7.3.0",
+    "neat-csv": "^6.0.1"
   },
   "devDependencies": {
     "@types/graphql": "^14.0.0",

--- a/app/subscriptions/src/utils.ts
+++ b/app/subscriptions/src/utils.ts
@@ -2,6 +2,7 @@ import { SockerManagerConfig } from './main'
 import yaml from 'js-yaml'
 import fs from 'fs'
 import path from 'path'
+import neatCsv = require("neat-csv");
 
 export const GQL = {
   START: 'start',
@@ -25,6 +26,7 @@ function* makeRangeIterator(start, end) {
 }
 
 const isRangeVariable = (obj) => obj.start != null && obj.end != null
+
 export function* argumentGenerator(args) {
   // Clone holds the original args, and the iterator values
   let internal = Object.assign({}, args)
@@ -62,6 +64,11 @@ export interface QueryConfig {
   connections_per_second: number
   query: string
   variables: Record<string, Range | number | string | object | any[]>
+  variable_file?: VariableFile
+}
+
+export interface VariableFile {
+  file_path: string
 }
 
 export interface Range {
@@ -69,9 +76,9 @@ export interface Range {
   end: number
 }
 
-export const yamlConfigToSocketManagerParams = (
+export const yamlConfigToSocketManagerParams = async (
   options: SubscriptionBenchConfig
-): SockerManagerConfig => ({
+): Promise<SockerManagerConfig> => ({
   label: options.config.label,
   endpoint: options.url,
   variables: options.config.variables,
@@ -81,6 +88,7 @@ export const yamlConfigToSocketManagerParams = (
   pgConnectionString: options.db_connection_string,
   subscriptionString: options.config.query,
   insertPayloadData: options.config.insert_payload_data ?? true,
+  fileVariables: await Utils.readVariablesFromFile(options)
 })
 
 export const COLORS = {
@@ -90,4 +98,38 @@ export const COLORS = {
   FG_RED: '\x1b[31m',
   RESET: '\x1b[0m',
   BLINK: '\x1b[5m',
+}
+
+export class Utils {
+
+  /**
+   * Asynchronously Read values from the CSV file and output as an Array of JSON values. The JSOn Object keys are the first row in the file, 
+   * which must also be the variable name. Also supports nested Variables which are themselves JSON.
+   * 
+   * @param bench Benchmark
+   * @returns neatCsv.Row[] - Array of objects pertaining to each row in the CSV file/Empty Array
+   */
+  static async readVariablesFromFile(bench: SubscriptionBenchConfig) {
+      let output: neatCsv.Row[] = [];
+      if (
+          bench.config.variable_file?.file_path 
+      ) {
+          let varCsvFile = fs.createReadStream(
+              path.join(process.cwd(), bench.config.variable_file?.file_path)
+          );
+          let rows = await neatCsv(varCsvFile);
+          rows.forEach((row) => {
+              const keys = Object.keys(row);
+              keys.forEach((key) => {
+                  try {
+                      row[key] = JSON.parse(row[key]);
+                  } catch (error) {
+                      // Suppress the unparseable json error.
+                  }
+              });
+          });
+          output = rows;
+      }
+      return output;
+  }
 }


### PR DESCRIPTION
This PR adds an optional config param, `variable_file` which takes the path to a CSV file which contains a list of variables supplied to the Query/Subscription. Each request fired from the bench marking tool will have a different variable (similar to the current `{start: 1, end: 10}` variable config for subscriptions). 