### PR TITLE
Tweaks to visualizations, add a new regression/comparison view mode

### DIFF
--- a/app/web-app/README.md
+++ b/app/web-app/README.md
@@ -9,3 +9,15 @@ You can aslo display a specific report by including the URL to the JSON in the
 URL fragment (assuming CORS is configured properly), for example:
 
 https://hasura.github.io/graphql-bench/app/web-app/#https://hasura-benchmark-results.s3.us-east-2.amazonaws.com/mono-pr-1866/chinook.json
+
+...or using the shorthand form for:
+
+https://hasura.github.io/graphql-bench/app/web-app/#mono-pr-1866/chinook
+
+Multiple reports can be specified (or chosen using the file-picker) to display
+a regression report that compares each individual benchmark across runs:
+
+https://hasura.github.io/graphql-bench/app/web-app/#mono-pr-1866/chinook,mono-pr-1849/chinook,mono-pr-1843/chinook
+
+Visualizations will assume the list of runs is in reverse chronological order,
+but this mostly doesn't matter.

--- a/app/web-app/index.html
+++ b/app/web-app/index.html
@@ -12,6 +12,15 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-crosshair@1.1.6"></script>
+    <!-- Dependencies for Zoom plugin: -->
+    <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@0.7.7"></script>
+    <script type="module">
+      // see https://www.skypack.dev/view/color-interpolate for README
+      import colorInterpolate from "https://cdn.skypack.dev/color-interpolate"
+      // expose in index.js
+      window.colorInterpolate = colorInterpolate
+    </script>
     <!-- MetricsGraphics required for scatterplot and grouped bar-charts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/metrics-graphics/3.0-alpha3/metricsgraphics.js"></script>
 
@@ -27,7 +36,8 @@
 
   <body class="font-sans leading-normal tracking-normal bg-gray-400">
     <div id="app"></div>
-    <script src="./index.js"></script>
+    <!-- NOTE: we need this to load after the type="module" import above, which has an implicit defer, hence the defer here -->
+    <script src="./index.js" defer></script>
   </body>
 
   <style>

--- a/app/web-app/index.js
+++ b/app/web-app/index.js
@@ -25,10 +25,13 @@ const getColor = () => {
   return colorList[num]
 }
 
+// For the Latency Percentiles Graph:
+const hist_points = ['min', 'p50', 'p75', 'p90', 'p99', 'p99_9', 'max']
+const hist_labels = ['min',  '50%', '75%', '90%', '99%', '99.9%','max']
+
 const makeChartJSDataset = (benchDataEntry) => {
   const label = benchDataEntry.name
-  const points = ['p50', 'p75', 'p90', 'p99', 'p99_9', 'p99_99']
-  const data = points.map((p) => benchDataEntry.histogram.json[p])
+  const data = hist_points.map((p) => benchDataEntry.histogram.json[p])
   return {
     label,
     data,
@@ -601,7 +604,7 @@ app.component('LatencyLineChart', {
         maintainAspectRatio: false,
         type: 'line',
         data: {
-          labels: ['50%', '75%', '90%', '99%', '99.9%', '99.99%'],
+          labels: hist_labels,
           datasets: props.benchData.map(makeChartJSDataset),
         },
         options: {

--- a/app/web-app/index.js
+++ b/app/web-app/index.js
@@ -58,6 +58,53 @@ const benchmarkEntryToTableValue = (item) => {
   }
 }
 
+const hasuraBenchmarksURL = `https://hasura-benchmark-results.s3.us-east-2.amazonaws.com`
+
+// async fetch all URLs in the list
+const fetchAllJSON = (urlsIds) => {
+  // Turn any shorthand identifiers like 'mono-pr-1866/chinook' into full URLs
+  // pointing to our report S3 bucket
+  const urls = urlsIds.map( (u) => {
+    if (u.startsWith("mono-pr-")) {
+      return `${hasuraBenchmarksURL}/${u}.json`
+    } else if (u.startsWith("http")) {
+      return u
+    } else {
+      throw `Identifiers in the URL hash need to be either a full URL, or like 'mono-pr-1234/chinook', not ${u}`
+    }
+
+  })
+  return Promise.all( urls.map( (url) => 
+    fetch(url, {mode:'cors'})
+      .then(response => response.json())
+  ))
+}
+
+// twiddle and filter data, and combine multiple reports into a single multiBenchData:
+const prepareMultiBenchData = (jsons, names) => {
+  const jsonsByName = jsons.map( (report, ix) => {
+    let benchmarksObj = {}
+    report.forEach( (b) => benchmarksObj[b.name] = {
+      ...b.histogram.json,
+      ...b.extended_hasura_checks,
+      // assume reports here are in the same order:
+      name: names[ix],
+    })
+    return benchmarksObj
+  })
+  // transpose the reports, so we get one array item per benchmark
+  let multiData = {}
+  jsonsByName.forEach( (report) =>  {
+    for (const [benchName, benchData] of Object.entries(report)) {
+      if (!(benchName in multiData)) {
+        multiData[benchName] = []
+      }
+      multiData[benchName].push(benchData)
+    }
+  })
+  return multiData
+}
+
 const Main = {
   template: /* html */ `
     <div>
@@ -67,19 +114,19 @@ const Main = {
       <!-- <MainContent /> -->
       <div id="main-content" class="container m-auto">
 
-      <section v-if="benchData.length == 0">
+      <section v-if="benchData.length == 0 && Object.keys(multiBenchData).length === 0">
         <!-- File upload -->
         <label style="margin: auto;" class="w-64 flex flex-col items-center px-4 py-6 bg-white text-blue-400 rounded-lg shadow-lg tracking-wide uppercase border border-blue-400 cursor-pointer hover:bg-blue-400  hover:text-white">
           <svg class="w-8 h-8" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
               <path d="M16.88 9.1A4 4 0 0 1 16 17H5a5 5 0 0 1-1-9.9V7a3 3 0 0 1 4.52-2.59A4.98 4.98 0 0 1 17 8c0 .38-.04.74-.12 1.1zM11 11h3l-4-4-4 4h3v3h2v-3z" />
           </svg>
-          <span class="mt-2 text-base leading-normal">Select a file</span>
-          <input type='file' class="hidden" @change="handleFileUpload" />
+          <span class="mt-2 text-base leading-normal">Select one or more JSON reports</span>
+          <input type='file' class="hidden" @change="handleFileUpload" multiple/>
         </label>
       </section>
 
       <!-- Visualize a single benchmark set: -->
-      <section v-else>
+      <section v-if="benchData && benchData.length > 0">
         <h1 class="py-4 mb-10 text-3xl border-b">
           Latency
         </h1>
@@ -91,37 +138,99 @@ const Main = {
           <AggregateScatterPlot title="Response Time Scatterplot" :bench-data="benchData" :height="350" :width="700" />
           <MeanBarChart title="Mean Latencies" :bench-data="benchData" :height="350" :width="300" />
         </div>
-        <div class="flex flex-row m-5" v-if="benchData.length != 0 && benchData[0].extended_hasura_checks">
+        <div class="flex flex-row m-5" v-if="benchData && benchData.length > 0 && benchData[0].extended_hasura_checks">
           <MemoryStats title="Memory and Allocation Stats (bytes)" :bench-data="benchData" :height="350" />
         </div>
         <DataTable :bench-data="benchData" />
+      </section>
+
+      <!-- Visualize several benchmark reports, showing regressions -->
+      <section v-if="multiBenchData && Object.keys(multiBenchData).length !== 0">
+        <h1 class="py-4 mb-10 text-3xl border-b">
+          Latency Percentiles Across Reports, For Each Benchmark
+        </h1>
+        <span class="py-4 mb-10 text-1xl">
+          <strong>NOTE</strong>: If the benchmark runs we're visualizing were passed in the URL
+          hash in e.g. reverse chronological order then they will be colored
+          here in that order, with most recent runs dark red fading into light
+          blue, and then dark blue for the oldest report. The charts below can
+          be <strong>zoomed</strong> with the mouse wheel.
+        </span>
+        
+        <div v-for="(benchData, benchName) in multiBenchData" style="padding: 10px">
+          <MultiLatencyLineChart :bench-data="benchData" :bench-name="benchName"/>
+        </div>
+
+        <h1 class="py-4 mb-10 text-3xl border-b">
+          Memory Usage and Allocation Metrics
+        </h1>
+        <div v-for="(benchData, benchName) in multiBenchData" style="padding: 10px">
+          <h2 class="py-4 mb-10 text-2xl border-b">
+            {{benchName.replace('-k6-custom','')}}
+          </h2>
+          <!-- Skip if this report doesn't have extended_hasura_checks -->
+          <div class="flex" v-if="('bytes_allocated_per_request' in benchData[0])">
+            <MemoryMultiBarChart :bench-data="benchData" :title="'Bytes allocated per request'" :metric="'bytes_allocated_per_request'" />
+            <MemoryMultiBarChart :bench-data="benchData" :title="'\\'mem_in_use\\', after bench run'" :metric="'mem_in_use_bytes_after'" />
+            <MemoryMultiBarChart :bench-data="benchData" :title="'\\'live_bytes\\', after bench run'" :metric="'live_bytes_after'" />
+          </div>
+        </div>
       </section>
       </div>
     </div>
   `,
   setup() {
-    let benchData = ref([])
+    // Data from a single JSON report.
+    //
+    // (Set this to false briefly to hide the file picker while we potentially
+    // fetch json asynchronously):
+    let benchData = ref(false)
+    
+    // Data aggregated from two or more JSON reports, which we'll present as a
+    // regression report
+    let multiBenchData = ref({})
+    // NOTE: we only ever have EITHER `benchData` OR `multiBenchData` defined.
+    //       Morally it's an enum/sum type.
 
     // We optionally take a comma-separated list of json report URLs to plot in
     // the URL fragment, and bypass asking for a local file. The remote must
     // have CORS configured properly.
-    // TODO when more than one URL, show regression-style report
     // NOTE: comma is techniquely valid in URL so using comma as the separator
     //       is not robust, but this seems unlikely to happen in practice
     if (window.location.hash){
-      var urls = window.location.hash.substring(1).split(',')
-      fetch(urls[0], {mode:'cors'})
-        .then(response => response.json())
-        .then(data => benchData.value = data)
+      var urlsIds = window.location.hash.substring(1).split(',')
+      fetchAllJSON(urlsIds)
+        .then(jsons => {
+          // We're generating single run report:
+          if (jsons.length == 1) {
+            benchData.value = jsons[0]
+
+          // We're generating a regression report from multiBenchData:
+          } else {
+            multiBenchData.value = prepareMultiBenchData(jsons, urlsIds)
+          }
+        })
+    } else {
+      // Report data will come from file-picker
+      benchData.value = []
     }
 
     const handleFileUpload = async (event) => {
-      const file = event.target.files[0]
-      const content = await file.text()
-      benchData.value = JSON.parse(content)
+      // We're generating a regression report from multiBenchData:
+      if (event.target.files.length > 1) {
+        let files = Array.from(event.target.files)
+        const filesText = await Promise.all(files.map((f) => f.text()))
+        const filesJson = filesText.map(JSON.parse)
+        multiBenchData.value = prepareMultiBenchData(filesJson, files.map((f) => f.name))
+      // We're generating single run report:
+      } else {
+        const file = event.target.files[0]
+        const content = await file.text()
+        benchData.value = JSON.parse(content)
+      }
     }
 
-    return { benchData, handleFileUpload }
+    return { benchData, handleFileUpload, multiBenchData }
   },
 }
 
@@ -579,6 +688,97 @@ app.component('DataTable', {
   },
 })
 
+// Options for our hdr-histogram-style line chart, factored out for re-use:
+const makeLatencyLineChartOptions = (otherPlugins) => {
+  return {
+    tooltips: {
+      mode: 'interpolate',
+      intersect: false,
+    },
+    hover: {
+      intersect: false,
+    },
+    plugins: {
+      ...otherPlugins,
+      crosshair: {
+        line: {
+          color: 'black', // crosshair line color
+          width: 0.75, // crosshair line width
+          //dashPattern: [15, 3, 3, 3], // crosshair line dash pattern
+        },
+        sync: {
+          enabled: true, // enable trace line syncing with other charts
+          group: 1, // chart group
+          suppressTooltips: false, // suppress tooltips when showing a synced tracer
+        },
+        snap: {
+          enabled: true,
+        },
+        zoom: {
+          enabled: true, // enable zooming
+          zoomboxBackgroundColor: 'rgba(66,133,244,0.2)', // background color of zoom box
+          zoomboxBorderColor: '#48F', // border color of zoom box
+          zoomButtonText: 'Reset Zoom', // reset zoom button text
+          zoomButtonClass: 'reset-zoom', // reset zoom button class
+        },
+        callbacks: {
+          beforeZoom: function (start, end) {
+            // called before zoom, return false to prevent zoom
+            return true
+          },
+          afterZoom: function (start, end) {
+            // called after zoom
+          },
+        },
+      },
+    },
+    scales: {
+      xAxes: [
+        {
+          scaleLabel: {
+            display: true,
+            labelString: 'Latency Percentile',
+          },
+          gridLines: {
+            display: true,
+            zeroLineColor: 'black',
+            tickMarkLength: 3,
+          },
+          ticks: {
+            padding: 5,
+            fontSize: 12,
+            fontStyle: 'bold',
+          },
+        },
+      ],
+      yAxes: [
+        {
+          type: 'logarithmic',
+          position: 'left',
+          gridLines: {
+            display: true,
+            lineWidth: 1,
+            tickMarkLength: 1,
+          },
+          scaleLabel: {
+            display: true,
+            labelString: 'Response Time (ms)',
+          },
+          ticks: {
+            maxTicksLimit: 10,
+            padding: 5,
+            fontSize: 12,
+            fontStyle: 'bold',
+            callback: (value, index, allValues) => {
+              return value
+            },
+          },
+        },
+      ],
+    },
+  }
+}
+
 app.component('LatencyLineChart', {
   props: {
     benchData: Array,
@@ -611,95 +811,79 @@ app.component('LatencyLineChart', {
           labels: hist_labels,
           datasets: props.benchData.map(makeChartJSDataset),
         },
-        options: {
-          tooltips: {
-            mode: 'interpolate',
-            intersect: false,
+        options: makeLatencyLineChartOptions({}),
+      })
+    })
+
+    return { chartElem }
+  },
+})
+
+// A line chart like LatencyLineChart, but comparing the same benchmark across
+// different runs, when in multiBenchData mode:
+app.component('MultiLatencyLineChart', {
+  props: {
+    benchData: Array,
+    benchName: String,
+  },
+  template: /* html */ `
+      <div
+      class="bg-gray-200 rounded-lg shadow-xl"
+      style="
+        position: relative;
+        width: 800px;
+        height: 500px;
+        padding: 50px 20px;
+        margin: auto;
+      "
+    >
+      <h1>{{benchName.replace("-k6-custom","").replaceAll("_"," ")}}</h1>
+      <hr />
+      <canvas id="chart-container" ref="chartElem"></canvas>
+    </div>
+  `,
+  setup(props) {
+    const chartElem = ref(null)
+    onMounted(() => {
+      const makeDataset = (benchDataEntry, ix) => {
+        const label = benchDataEntry.name
+        const data = hist_points.map((p) => benchDataEntry[p])
+        return {
+          label,
+          data,
+          fill: false,
+          borderWidth: 2,
+          pointRadius: 2.5,
+          // This is a heatmap-style red to blue color scheme which lets us show
+          // the results "fading back in time":
+          borderColor: redToBlue(ix, props.benchData.length)
+          // pointBackgroundColor: 'white',
+        }
+      }
+      // Options to allow zooming: https://www.chartjs.org/chartjs-plugin-zoom/ 
+      const zoomOptions = {
+        zoom: {
+          pan: {
+            enabled: true,
           },
-          hover: {
-            intersect: false,
-          },
-          plugins: {
-            // colorschemes: {
-            //   scheme: "brewer.SetOne8"
-            // },
-            crosshair: {
-              line: {
-                color: 'black', // crosshair line color
-                width: 0.75, // crosshair line width
-                //dashPattern: [15, 3, 3, 3], // crosshair line dash pattern
-              },
-              sync: {
-                enabled: true, // enable trace line syncing with other charts
-                group: 1, // chart group
-                suppressTooltips: false, // suppress tooltips when showing a synced tracer
-              },
-              snap: {
-                enabled: true,
-              },
-              zoom: {
-                enabled: true, // enable zooming
-                zoomboxBackgroundColor: 'rgba(66,133,244,0.2)', // background color of zoom box
-                zoomboxBorderColor: '#48F', // border color of zoom box
-                zoomButtonText: 'Reset Zoom', // reset zoom button text
-                zoomButtonClass: 'reset-zoom', // reset zoom button class
-              },
-              callbacks: {
-                beforeZoom: function (start, end) {
-                  // called before zoom, return false to prevent zoom
-                  return true
-                },
-                afterZoom: function (start, end) {
-                  // called after zoom
-                },
-              },
-            },
-          },
-          scales: {
-            xAxes: [
-              {
-                scaleLabel: {
-                  display: true,
-                  labelString: 'Latency Percentile',
-                },
-                gridLines: {
-                  display: true,
-                  zeroLineColor: 'black',
-                  tickMarkLength: 3,
-                },
-                ticks: {
-                  padding: 5,
-                  fontSize: 12,
-                  fontStyle: 'bold',
-                },
-              },
-            ],
-            yAxes: [
-              {
-                type: 'logarithmic',
-                position: 'left',
-                gridLines: {
-                  display: true,
-                  lineWidth: 1,
-                  tickMarkLength: 1,
-                },
-                scaleLabel: {
-                  display: true,
-                  labelString: 'Response Time (ms)',
-                },
-                ticks: {
-                  maxTicksLimit: 10,
-                  padding: 5,
-                  fontSize: 12,
-                  fontStyle: 'bold',
-                  callback: (value, index, allValues) => {
-                    return value
-                  },
-                },
-              },
-            ],
-          },
+          zoom: {
+            enabled: true,
+            mode: 'y',
+          }
+        }
+      }
+
+      const ctx = chartElem.value.getContext('2d')
+      const myChart = new Chart(ctx, {
+        responsive: true,
+        maintainAspectRatio: false,
+        type: 'line',
+        data: {
+          labels: hist_labels,
+          datasets: props.benchData.map(makeDataset),
         },
+        options: makeLatencyLineChartOptions(zoomOptions),
+        // options: makeLatencyLineChartOptions({colorschemes: { scheme: "brewer.RdYlBu11" }}),
       })
     })
 
@@ -757,6 +941,99 @@ app.component('MeanBarChart', {
     </div>
   `,
 })
+
+// return a color uniformly along a gradient for an element in a list at index
+// `ix`, where the list has length `totalCount`
+const redToBlue = (ix, totalCount) => {
+  // This is a copy of the brewer.RdYlBu11 colorscheme:
+  const redToBlue11Scheme = ["#a50026", "#d73027", "#f46d43", "#fdae61", "#fee090", "#ffffbf", "#e0f3f8", "#abd9e9", "#74add1", "#4575b4", "#313695"]
+  const color = window.colorInterpolate(redToBlue11Scheme)
+  return color(ix/(totalCount-1))
+}
+const redToBlueArray = (totalCount) => {
+  return [...Array(totalCount).keys()].map((ix) => redToBlue(ix, totalCount))
+}
+
+// This one gets used to show the different memory stats as a simple bar chart,
+// when in multiBenchData mode:
+app.component('MemoryMultiBarChart', {
+  props: {
+    benchData: Array,
+    title: String,
+    metric: String,
+  },
+  setup(props) {
+    var data = []
+    var labels = []
+    props.benchData.forEach((it) => {
+      labels.push(it.name)
+      data.push(Number(it[props.metric].toFixed(2)))
+    })
+
+    const chartElem = ref(null)
+    onMounted(() => {
+      const ctx = chartElem.value.getContext('2d')
+      const myChart = new Chart(ctx, {
+        responsive: true,
+        maintainAspectRatio: false,
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: props.title,
+            data,
+            borderColor: [],
+            borderWidth: 2,
+            backgroundColor: redToBlueArray(data.length),
+          }],
+        },
+        options: {
+          maintainAspectRatio: false,
+          responsive: true,
+          scales: {
+            yAxes: [
+              {
+                position: 'left',
+                gridLines: {
+                  display: true,
+                  lineWidth: 1,
+                  tickMarkLength: 1,
+                },
+                scaleLabel: {
+                  display: true,
+                  labelString: 'Memory/Allocation',
+                },
+                ticks: {
+                  beginAtZero: true,
+                  maxTicksLimit: 10,
+                  padding: 5,
+                  fontSize: 12,
+                  fontStyle: 'bold',
+                  callback: (value, index, allValues) => {
+                    // Bytes to megabytes:
+                    return (value/1_000_000).toFixed(1)+" MB"
+                  },
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+    return { chartElem }
+  },
+  template: /* html */ `
+      <div
+      style="
+        height: 400px;
+      "
+      class="bg-gray-200 rounded-lg shadow-xl flex1 bg-gray-200 rounded-md shadow-lg p-4 mx-5 w-2/5 h-128"
+    >
+      <canvas ref="chartElem"></canvas>
+    </div>
+  `,
+})
+
 
 app.component('AggregateScatterPlot', {
   props: {


### PR DESCRIPTION
Here are screenshots of changes to the original mode, used to compare **different benchmarks within a single run**:

![3](https://user-images.githubusercontent.com/210815/128085317-1ca0161f-df61-425c-9664-cf875dbfc05b.png)

![4](https://user-images.githubusercontent.com/210815/128085333-740f97a2-2249-4b50-8716-7c04c167c8e5.png)

And here is the new mode, which we can use to **compare the same benchmark across _different_ runs**:

![1](https://user-images.githubusercontent.com/210815/128085402-c845e742-91f7-4dc1-b625-d6f1cf8873a7.png)

![2](https://user-images.githubusercontent.com/210815/128085413-ad6be802-a647-4952-aa97-edf4fba8a196.png)
