### PR TITLE
Fix schema of postgres table storing subscription results on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,18 +255,18 @@ For the Subscriptions test to record data in the DB, it requires a table `events
 ```sql
 CREATE TABLE public.events (
   -- unique label to identify benchmark
-  label text NOT NULL
+  label text NOT NULL,
   -- connection_id represents the n'th connection
-  connection_id int NOT NULL
-  operation_id int NOT NULL
+  connection_id int NOT NULL,
+  operation_id int NOT NULL,
   -- event_number represents the nth event that was received by the client
-  event_number int NOT NULL
+  event_number int NOT NULL,
   -- event_data stores the payload that was received
-  event_data jsonb NOT NULL
+  event_data jsonb NOT NULL,
   -- event_time stores the time at which the event was received by the client
-  event_time timestamptz NOT NULL
+  event_time timestamptz NOT NULL,
   -- is_error represents whether the event was error or not
-  is_error boolean NOT NULL
+  is_error boolean NOT NULL,
   --  latency is not populated by the benchmark tool, but this can be populated by calculating event_time - <event_triggered_time>
   latency int
 )


### PR DESCRIPTION
The schema for the postgres table in the README was wrong, so I fixed it.