### PR TITLE
web-app: migrate to chart.js v3, other small improvements

### DIFF
--- a/app/web-app/index.html
+++ b/app/web-app/index.html
@@ -9,12 +9,11 @@
     <!-- D3 v4 required for MetricsGraphics.js charts -->
     <script src="https://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <!-- Chart.js required for latency percentiles line chart -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-crosshair@1.1.6"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-crosshair@1.2.0"></script>
     <!-- Dependencies for Zoom plugin: -->
     <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@0.7.7"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@1.2.1"></script>
     <script type="module">
       // see https://www.skypack.dev/view/color-interpolate for README
       import colorInterpolate from "https://cdn.skypack.dev/color-interpolate"

--- a/app/web-app/index.js
+++ b/app/web-app/index.js
@@ -796,7 +796,7 @@ app.component('LatencyLineChart', {
       minDataPoint = Math.min(minDataPoint, benchDataEntry.histogram.json['min'])
       maxDataPoint = Math.max(maxDataPoint, benchDataEntry.histogram.json['max'])
       const label = benchDataEntry.name
-      const data = hist_points.map((p) => benchDataEntry.histogram.json[p])
+      const data = hist_points.map((p) => benchDataEntry.histogram.json[p] || null)  // null, for spanGaps
       return {
         label,
         data,
@@ -808,6 +808,7 @@ app.component('LatencyLineChart', {
         // Smooth lines, but monotone (no misleading up/down "swooping" to fit data points)
         cubicInterpolationMode: 'monotone',
         // tension: 0.4, //... I'm not convinced this actually does anything...
+        spanGaps: true,  // span missing data points, for adhoc results
       }
     }
 
@@ -866,7 +867,7 @@ app.component('MultiLatencyLineChart', {
         minDataPoint = Math.min(minDataPoint, benchDataEntry['min'])
         maxDataPoint = Math.max(maxDataPoint, benchDataEntry['max'])
         const label = benchDataEntry.name
-        const data = hist_points.map((p) => benchDataEntry[p])
+        const data = hist_points.map((p) => benchDataEntry[p] || null) // null, for spanGaps
         return {
           label,
           data,
@@ -879,6 +880,7 @@ app.component('MultiLatencyLineChart', {
           // pointBackgroundColor: 'white',
           // Smooth lines, but monotone (no misleading up/down "swooping" to fit data points)
           cubicInterpolationMode: 'monotone',
+          spanGaps: true,  // span missing data points, for adhoc results
         }
       }
       // Options to allow zooming: https://www.chartjs.org/chartjs-plugin-zoom/ 

--- a/app/web-app/index.js
+++ b/app/web-app/index.js
@@ -1,3 +1,9 @@
+// Reload when user edits fragment to select different benchmark results:
+function locationHashChanged() {
+  window.location.reload(); 
+}
+window.onhashchange = locationHashChanged;
+
 // @ts-nocheck
 const { ref, reactive, computed, watch, watchEffect, onMounted } = Vue
 

--- a/app/web-app/index.js
+++ b/app/web-app/index.js
@@ -683,15 +683,15 @@ app.component('DataTable', {
 // Options for our hdr-histogram-style line chart, factored out for re-use:
 const makeLatencyLineChartOptions = (minDataPoint, maxDataPoint, otherPlugins, enable_crosshair_zoom = true) => {
   return {
-    tooltips: {
-      mode: 'interpolate',
-      intersect: false,
-    },
     hover: {
       intersect: false,
     },
     plugins: {
       ...otherPlugins,
+      tooltip: {
+        mode: 'interpolate',
+        intersect: false,
+      },
       crosshair: {
         line: {
           color: 'black', // crosshair line color
@@ -725,16 +725,15 @@ const makeLatencyLineChartOptions = (minDataPoint, maxDataPoint, otherPlugins, e
       },
     },
     scales: {
-      xAxes: [
-        {
-          scaleLabel: {
+      x: {
+          title: {
             display: true,
-            labelString: 'Latency Percentile',
+            text: 'Latency Percentile',
           },
-          gridLines: {
+          grid: {
+            color: (ctx) => (ctx.index === 0 ? 'black' : 'rgba(0, 0, 0, 0.1)'),
             display: true,
-            zeroLineColor: 'black',
-            tickMarkLength: 3,
+            tickLength: 3,
           },
           ticks: {
             padding: 5,
@@ -742,23 +741,24 @@ const makeLatencyLineChartOptions = (minDataPoint, maxDataPoint, otherPlugins, e
             fontStyle: 'bold',
           },
         },
-      ],
-      yAxes: [
-        {
+      y: {
           type: 'logarithmic',
+          // This is to work around a new v3 bug: https://github.com/chartjs/Chart.js/issues/10644
+          // It sometimes doesn't work, and sometimes looks like shit:
+          afterBuildTicks: axis => axis.ticks.push({"value": maxDataPoint}),
           position: 'left',
-          gridLines: {
+          grid: {
             display: true,
             lineWidth: 1,
-            tickMarkLength: 1,
+            tickLength: 1,
           },
-          scaleLabel: {
+          title: {
             display: true,
-            labelString: 'Response Time (ms)',
+            text: 'Response Time (ms)',
           },
+          min: minDataPoint,
+          max: maxDataPoint,
           ticks: {
-            min: minDataPoint,
-            max: maxDataPoint,
             maxTicksLimit: 10,
             padding: 5,
             fontSize: 12,
@@ -768,7 +768,6 @@ const makeLatencyLineChartOptions = (minDataPoint, maxDataPoint, otherPlugins, e
             },
           },
         },
-      ],
     },
   }
 }
@@ -803,6 +802,7 @@ app.component('LatencyLineChart', {
       maxDataPoint = Math.max(maxDataPoint, benchDataEntry.histogram.json['max'])
       const label = benchDataEntry.name
       const data = hist_points.map((p) => benchDataEntry.histogram.json[p] || null)  // null, for spanGaps
+      const color = getColor()
       return {
         label,
         data,
@@ -810,7 +810,8 @@ app.component('LatencyLineChart', {
         borderWidth: 1,
         pointRadius: 2.5,
         pointBackgroundColor: 'white',
-        borderColor: getColor(),
+        borderColor:     color,
+        backgroundColor: color,
         // Smooth lines, but monotone (no misleading up/down "swooping" to fit data points)
         cubicInterpolationMode: 'monotone',
         // tension: 0.4, //... I'm not convinced this actually does anything...
@@ -874,6 +875,7 @@ app.component('MultiLatencyLineChart', {
         maxDataPoint = Math.max(maxDataPoint, benchDataEntry['max'])
         const label = benchDataEntry.name
         const data = hist_points.map((p) => benchDataEntry[p] || null) // null, for spanGaps
+        const color = redToBlue(ix, props.benchData.length)
         return {
           label,
           data,
@@ -882,7 +884,8 @@ app.component('MultiLatencyLineChart', {
           pointRadius: 0,  // disable points, which looks cluttered
           // This is a heatmap-style red to blue color scheme which lets us show
           // the results "fading back in time":
-          borderColor: redToBlue(ix, props.benchData.length),
+          borderColor:     color,
+          backgroundColor: color,
           // pointBackgroundColor: 'white',
           // Smooth lines, but monotone (no misleading up/down "swooping" to fit data points)
           cubicInterpolationMode: 'monotone',
@@ -896,7 +899,12 @@ app.component('MultiLatencyLineChart', {
             enabled: true,
           },
           zoom: {
-            enabled: true,
+            pinch: {
+              enabled: true,
+            },
+            wheel: {
+              enabled: true,
+            },
             mode: 'y',
           }
         }
@@ -914,7 +922,6 @@ app.component('MultiLatencyLineChart', {
         },
         // NOTE: this isn't really compatible with crosshair.zoom, so we disable that here:
         options: makeLatencyLineChartOptions(minDataPoint, maxDataPoint, zoomOptions, false),
-        // options: makeLatencyLineChartOptions({colorschemes: { scheme: "brewer.RdYlBu11" }}),
       })
     })
 
@@ -1013,7 +1020,7 @@ app.component('MemoryMultiBarChart', {
           datasets: [{
             label: props.title,
             data,
-            borderColor: [],
+            // borderColor: [],
             borderWidth: 2,
             backgroundColor: redToBlueArray(data.length),
           }],
@@ -1022,20 +1029,19 @@ app.component('MemoryMultiBarChart', {
           maintainAspectRatio: false,
           responsive: true,
           scales: {
-            yAxes: [
-              {
+            y: {
                 position: 'left',
-                gridLines: {
+                beginAtZero: true,
+                grid: {
                   display: true,
                   lineWidth: 1,
-                  tickMarkLength: 1,
+                  tickLength: 1,
                 },
-                scaleLabel: {
+                title: {
                   display: true,
-                  labelString: 'Memory/Allocation',
+                  text: 'Memory/Allocation',
                 },
                 ticks: {
-                  beginAtZero: true,
                   maxTicksLimit: 10,
                   padding: 5,
                   fontSize: 12,
@@ -1046,7 +1052,6 @@ app.component('MemoryMultiBarChart', {
                   },
                 },
               },
-            ],
           },
         },
       })


### PR DESCRIPTION
This is to unblock reusing the web-app for visualizing "ad hoc" benchmarks (e.g. metadata queries), in graphql-engine