### PR TITLE
Tweak PreciseHdrHistogram and collect geometric mean and a basic histogram

### DIFF
--- a/app/queries/src/PreciseHdrHistogram.ts
+++ b/app/queries/src/PreciseHdrHistogram.ts
@@ -5,14 +5,14 @@ import { HDRHistogramParsedStats } from './executors/base/types'
 /* A wrapper for Histogram that gets us more precision. See
  * https://github.com/HdrHistogram/HdrHistogramJS/issues/35
  *
- * Values inserted will be truncated to `logBase 10 scalingFactor` (i.e. 3)
+ * Values inserted will be truncated to `logBase 10 scalingFactor` (i.e. 4)
  * decimal places.
  */
 export class PreciseHdrHistogram {
   // We'll need to multiply by scalingFactor anything we insert, and divide by scalingFactor
   // anything we output from here:
   private _histogramDirty: hdr.Histogram
-  static scalingFactor: number = 1000
+  static scalingFactor: number = 10000
 
   constructor(
     request: hdr.BuildRequest
@@ -76,7 +76,8 @@ export const defaultRequest: hdr.BuildRequest = {
   autoResize: true,
   lowestDiscernibleValue: 1,
   highestTrackableValue: 2,
-  numberOfSignificantValueDigits: 3,
+  // NOTE: the default 'hdr-histogram-js' is 3, but we'll set it to the max of 5 here:
+  numberOfSignificantValueDigits: 5,
   useWebAssembly: false,
 }
 

--- a/app/queries/src/executors/base/index.ts
+++ b/app/queries/src/executors/base/index.ts
@@ -33,7 +33,7 @@ export function parseHdrHistogramText(text: string): HDRHistogramParsedStats[] {
 export function makeBenchmarkMetrics(
   params: BenchmarkMetricParams
 ): BenchmarkMetrics {
-  const { name, histogram, time, requests, response } = params
+  const { name, histogram, basicHistogram, time, requests, response, geoMean } = params
   return {
     name,
     time,
@@ -43,11 +43,13 @@ export function makeBenchmarkMetrics(
       json: {
         ...histogram.toJSON(),
         mean: histogram.mean,
+        geoMean,
         min: histogram.min,
         stdDeviation: histogram.stdDeviation,
       },
       parsedStats: histogram.parsedStats,
     },
+    basicHistogram,
   }
 }
 

--- a/app/queries/src/executors/base/index.ts
+++ b/app/queries/src/executors/base/index.ts
@@ -33,7 +33,7 @@ export function parseHdrHistogramText(text: string): HDRHistogramParsedStats[] {
 export function makeBenchmarkMetrics(
   params: BenchmarkMetricParams
 ): BenchmarkMetrics {
-  const { name, histogram, basicHistogram, time, requests, response, geoMean } = params
+  const { name, histogram, basicHistogram, time, requests, response, geoMean, p501stHalf, p501stQuarter, p501stEighth, geoMean1stHalf, geoMean1stQuarter, geoMean1stEighth } = params
   return {
     name,
     time,
@@ -44,6 +44,12 @@ export function makeBenchmarkMetrics(
         ...histogram.toJSON(),
         mean: histogram.mean,
         geoMean,
+        p501stHalf,
+        p501stQuarter,
+        p501stEighth,
+        geoMean1stHalf,
+        geoMean1stQuarter,
+        geoMean1stEighth,
         min: histogram.min,
         stdDeviation: histogram.stdDeviation,
       },

--- a/app/queries/src/executors/base/types.ts
+++ b/app/queries/src/executors/base/types.ts
@@ -133,8 +133,10 @@ export interface HDRHistogramParsedStats {
   ofOnePercentile: string
 }
 
-export interface HistogramSummaryWithMeanMinAndStdDev extends HistogramSummary {
+// add some extra statistics:
+export interface HistogramSummaryWithEtc extends HistogramSummary {
   mean: number
+  geoMean?: number
   min: number
   stdDeviation: number
 }
@@ -154,9 +156,11 @@ export interface BenchmarkMetrics {
     bytesPerSecond: number
   }
   histogram: {
-    json: HistogramSummaryWithMeanMinAndStdDev
+    json: HistogramSummaryWithEtc
     parsedStats: HDRHistogramParsedStats[]
   }
+  // A basic histogram with equal size buckets (the hdr histogram above predates this):
+  basicHistogram?: HistBucket[]
   // These are available when 'extended_hasura_checks: true' in the config yaml:
   extended_hasura_checks?: {
     bytes_allocated_per_request: number
@@ -172,6 +176,7 @@ export interface BenchmarkMetrics {
 export interface BenchmarkMetricParams {
   name: string
   histogram: precise_hdr.PreciseHdrHistogram
+  basicHistogram?: HistBucket[]
   time: {
     start: Date | string
     end: Date | string
@@ -183,5 +188,15 @@ export interface BenchmarkMetricParams {
   response: {
     totalBytes: number
     bytesPerSecond: number
-  }
+  },
+  // geometric mean of service times
+  geoMean?: number
+}
+
+// See histogram()
+//
+// there are 'count' values in the bucket greater than 'gte'
+export interface HistBucket {
+    gte: number,
+    count: number
 }

--- a/app/queries/src/executors/k6/index.ts
+++ b/app/queries/src/executors/k6/index.ts
@@ -13,6 +13,7 @@ import {
   MultiStageBenchmark,
   RequestsPerSecondBenchmark,
   HistBucket,
+  BasicHistogram,
 } from '../base/types'
 
 import {
@@ -239,7 +240,8 @@ export class K6Executor extends BenchmarkExecutor {
     const metrics = makeBenchmarkMetrics({
       name: metadata.queryName,
       histogram: hdrHistogram,
-      basicHistogram: histogram(200, reqDurations),
+      // filter some outliers to get better granularity for bulk of samples:
+      basicHistogram: histogram(100, reqDurations, hdrHistogram.toJSON().p99),
       time: {
         start: benchmarkStart.toISOString(),
         end: benchmarkEnd.toISOString(),
@@ -252,7 +254,13 @@ export class K6Executor extends BenchmarkExecutor {
         totalBytes: jsonStats.metrics.data_received.count,
         bytesPerSecond: jsonStats.metrics.data_received.rate,
       },
-      geoMean: geoMean(reqDurations)
+      geoMean: geoMean(reqDurations),
+      p501stHalf:    median(reqDurations.slice(0,reqDurations.length/2)),
+      p501stQuarter: median(reqDurations.slice(0,reqDurations.length/4)),
+      p501stEighth:  median(reqDurations.slice(0,reqDurations.length/8)),
+      geoMean1stHalf:    geoMean(reqDurations.slice(0,reqDurations.length/2)),
+      geoMean1stQuarter: geoMean(reqDurations.slice(0,reqDurations.length/4)),
+      geoMean1stEighth:  geoMean(reqDurations.slice(0,reqDurations.length/8)),
     })
 
     return metrics
@@ -264,39 +272,57 @@ function geoMean(xs: number[]): number {
     return xs.map(x => Math.pow(x, 1/xs.length)).reduce((acc, x) => acc * x)
 }
 
+// Generate a double histogram of the input numbers: one containing all the
+// data, and the other just the first half of the data. Optionally filtering
+// out outliers >= maxValue
+//
 // NOTE: To save space and aid readability we’ll filter out any buckets with a
 // count of 0 that follow a bucket with a count of 0. This can still be graphed
 // fine without extra accommodations using a stepped line plot, as we plan
-function histogram(numBuckets: number, xs: number[]): HistBucket[] {
+function histogram(numBuckets: number, xs: number[], maxValue: number = Number.MAX_SAFE_INTEGER): BasicHistogram {
     if (numBuckets < 1 || xs.length < 2) { throw "We need at least one bucket and xs.length > 1" }
     
-    var xsSorted = new Float64Array(xs) // so sort works properly
-    xsSorted.sort()
+    // sort list, keeping track of original index so we can determine which
+    // part of the data we're looking at
+    var outliersRemoved = 0
+    var xsSorted = xs.map((x, ix) => [x,ix])
+                     .filter(([x,_]) => { 
+                         let ok = x < maxValue
+                         if (!ok) outliersRemoved++
+                         return ok
+                     })
+    xsSorted.sort((a,b) => a[0] - b[0])
+    // index of last element in the first half of data:
+    const ix1stHalfLast = xs.length/2 - 1
     
-    const bucketWidth = (xsSorted[xsSorted.length - 1] - xsSorted[0]) / numBuckets
+    const bucketWidth = (xsSorted[xsSorted.length - 1][0] - xsSorted[0][0]) / numBuckets
      
-    var buckets = []
-    for (let gte = xsSorted[0] ; true ; gte+=bucketWidth) {
+    var buckets: HistBucket[] = []
+    for (let gte = xsSorted[0][0] ; true ; gte+=bucketWidth) {
         // Last bucket; add remaining and stop
         if (buckets.length === (numBuckets-1)) {
-            buckets.push({gte, count: xsSorted.length})
+            var count1stHalf = 0
+            xsSorted.map( ([_,ixOrig]) => { if (ixOrig <= ix1stHalfLast) count1stHalf++ })
+            buckets.push({gte, count: xsSorted.length, count1stHalf})
             break
         }
         var count = 0
+        var count1stHalf = 0
         var ixNext
         // this should always consume as least one value:
-        xsSorted.some((x, ix) => {
+        xsSorted.some(([x, ixOrig], ix) => {
             if (x < (gte+bucketWidth)) {
-                 count++
-                 return false // i.e. keep looping
+                count++
+                if (ixOrig <= ix1stHalfLast) count1stHalf++
+                return false // i.e. keep looping
             } else {
-                 ixNext = ix
-                 return true
+                ixNext = ix
+                return true
             }
         })
         if (ixNext === undefined) {throw "Bugs in histogram!"}
         xsSorted = xsSorted.slice(ixNext)
-        buckets.push({gte, count})
+        buckets.push({gte, count, count1stHalf})
     }
     // having at most one 0 bucket in a row, i.e. `{gte: n, count: 0}` means
     // "This and all higher buckets are empty"
@@ -315,5 +341,19 @@ function histogram(numBuckets: number, xs: number[]): HistBucket[] {
         }
     })
 
-    return bucketsSparse
+    return {buckets: bucketsSparse, outliersRemoved}
+}
+
+// Copy paste: https://stackoverflow.com/a/53660837/176841
+function median(numbers) {
+    if (numbers.length === 0) return 0 // I guess
+
+    const sorted = Float64Array.from(numbers).sort();
+    const middle = Math.floor(sorted.length / 2);
+
+    if (sorted.length % 2 === 0) {
+        return (sorted[middle - 1] + sorted[middle]) / 2;
+    }
+
+    return sorted[middle];
 }

--- a/app/web-app/index.html
+++ b/app/web-app/index.html
@@ -21,6 +21,7 @@
     </script>
     <!-- MetricsGraphics required for scatterplot and grouped bar-charts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/metrics-graphics/3.0-alpha3/metricsgraphics.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-crosshair@1.2.0"></script>
 
     <link
       rel="stylesheet"

--- a/app/web-app/index.html
+++ b/app/web-app/index.html
@@ -10,7 +10,6 @@
     <script src="https://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <!-- Chart.js required for latency percentiles line chart -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-crosshair@1.2.0"></script>
     <!-- Dependencies for Zoom plugin: -->
     <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@1.2.1"></script>


### PR DESCRIPTION
Tested CI on this here: https://github.com/hasura/graphql-engine-mono/pull/5803

Currently working on adding histograms to the graphs

I would have liked to add some unit tests, but wasn't really sure how to set that up. I played with both the geometric mean and the histogram function quite a bit in the repl, but let me know if you think we maybe need doc tests or something?

**EDIT**: here's an example of a new histogram entry:

![histnew](https://user-images.githubusercontent.com/210815/189437516-cbfc9acb-f618-43aa-9a66-6c223028cd23.png)
