### PR TITLE
Enable points on the multi latency line chart

### DIFF
--- a/app/web-app/index.js
+++ b/app/web-app/index.js
@@ -1118,7 +1118,6 @@ app.component('MultiLatencyLineChart', {
           data,
           fill: false,
           borderWidth: 1.5,
-          pointRadius: 0,  // disable points, which looks cluttered
           // This is a heatmap-style red to blue color scheme which lets us show
           // the results "fading back in time":
           borderColor:     color,

--- a/app/web-app/index.js
+++ b/app/web-app/index.js
@@ -1118,6 +1118,7 @@ app.component('MultiLatencyLineChart', {
           data,
           fill: false,
           borderWidth: 1.5,
+          pointRadius: ((props.benchData.length > 3) ? 0 : 3),
           // This is a heatmap-style red to blue color scheme which lets us show
           // the results "fading back in time":
           borderColor:     color,


### PR DESCRIPTION
In the latency charts, I find it hard to read the interpolated lines. I'd just like to see the data points. I think just re-enabling the "points" will do the trick.